### PR TITLE
20241128_hm_데이터병합 및 데이터 추가

### DIFF
--- a/data_precleaning.ipynb
+++ b/data_precleaning.ipynb
@@ -120,7 +120,18 @@
     "'''\n",
     "주거실태 데이터 프레임\n",
     "'''\n",
-    "abode_house_category = pd.read_csv(root + '주거실태_Data/주택의_종류별_주택__읍면동_연도_끝자리_0__5___시군구_그_외_연도__20241120174542.csv', encoding = 'cp949')"
+    "abode_house_category = pd.read_csv(root + '주거실태_Data/주택의_종류별_주택__읍면동_연도_끝자리_0__5___시군구_그_외_연도__20241120174542.csv', encoding = 'cp949')\n",
+    "\n",
+    "'''\n",
+    "매매가격지수\n",
+    "'''\n",
+    "# 기준시점과 매기 조사되는 조사시점의 가격비를 이용하여 기준시점이 100인 수치로 환산한 값을 의미\n",
+    "# 본 조사에서는 전월비와 전년 말비를 제공, 제공 산식을 활용하여 \n",
+    "# 원하는 두 시점의 가격 변동률을 구할 수 있음.\n",
+    "# 변동률(%) = {(110 - 105) / 105}X 100 = 4.76퍼센트(%)\n",
+    "\n",
+    "# 변동률(p) = 110 - 105 = 5포인트(p)\n",
+    "priceRelative_df = pd.read_csv(root + '수요공급_Data/매매가격지수_주택종합.csv',  encoding='cp949')"
    ]
   },
   {
@@ -442,7 +453,50 @@
     "    # '서울특별시'를 제외한 데이터만 선택\n",
     "    df_filtered = df_year[df_year['구'] != '서울특별시']\n",
     "\n",
-    "    return df_filtered"
+    "    return df_filtered\n",
+    "\n",
+    "'''\n",
+    "매매가격지수 전처리 함수\n",
+    "'''\n",
+    "def precleaning_priceRelative(df, year) :\n",
+    "  columns = df.columns.str.contains('.1')\n",
+    "  goo = df.loc[:, ~columns].columns[2:]\n",
+    "  goo_1 = df.loc[:, columns].columns\n",
+    "  # Wide-to-Long 변환\n",
+    "  df_long = pd.melt(\n",
+    "      df,\n",
+    "      id_vars=[\"자료시점\"],  # 고정할 열\n",
+    "      value_vars=goo,  # 변환할 열 (원자료)\n",
+    "      var_name=\"구\",  # 변환 후 열 이름\n",
+    "      value_name=\"원자료\",  # 값 열 이름\n",
+    "  )\n",
+    "  \n",
+    "  # 전기대비증감률 추가\n",
+    "  df_rate = pd.melt(\n",
+    "      df,\n",
+    "      id_vars=[\"자료시점\"],\n",
+    "      value_vars=goo_1,\n",
+    "      var_name=\"구\",\n",
+    "      value_name=\"전기대비증감률\",\n",
+    "  )\n",
+    "  \n",
+    "  # \"구\" 컬럼 정리\n",
+    "  df_long[\"구\"] = df_long[\"구\"].str.replace(\".1\", \"\")\n",
+    "  df_rate[\"구\"] = df_rate[\"구\"].str.replace(\".1\", \"\")\n",
+    "  \n",
+    "  # 최종 병합\n",
+    "  final_df = pd.merge(df_long, df_rate, on=[\"자료시점\", \"구\"])\n",
+    "  \n",
+    "  # 원하는 형식으로 정렬\n",
+    "  final_df = final_df[[\"자료시점\", \"구\", \"원자료\", \"전기대비증감률\"]]\n",
+    "  final_df = final_df.loc[1:, :]\n",
+    "  condition = final_df['자료시점'].str.contains(f\"{year}년\")\n",
+    "  final_year_df = final_df.loc[condition, :]\n",
+    "  final_year_df['원자료'] = final_year_df['원자료'].astype(float)\n",
+    "  final_year_df['전기대비증감률'] = final_year_df['전기대비증감률'].astype(float)\n",
+    "  final_year_df = final_year_df.groupby('구')[['원자료', '전기대비증감률']].mean().reset_index()\n",
+    "\n",
+    "  return final_year_df"
    ]
   },
   {
@@ -612,7 +666,13 @@
     "   # 주거실태 전처리 함수 적용\n",
     "abode_house_category_2021_df = precleaning_housereality(abode_house_category, '2021')\n",
     "abode_house_category_2022_df = precleaning_housereality(abode_house_category, '2022')\n",
-    "abode_house_category_2023_df = precleaning_housereality(abode_house_category, '2023')"
+    "abode_house_category_2023_df = precleaning_housereality(abode_house_category, '2023')\n",
+    "\n",
+    "    # 매매가격지수 전처리 함수 적용\n",
+    "priceRelative_2021_df = precleaning_priceRelative(priceRelative_df, '2021')\n",
+    "priceRelative_2022_df = precleaning_priceRelative(priceRelative_df, '2022')\n",
+    "priceRelative_2023_df = precleaning_priceRelative(priceRelative_df, '2023')\n",
+    "priceRelative_2024_df = precleaning_priceRelative(priceRelative_df, '2024')"
    ]
   },
   {
@@ -700,7 +760,15 @@
     "# '''\n",
     "# abode_house_category_2021_df.to_csv('전처리_주거실태_2021.csv', index=False, encoding='cp949')\n",
     "# abode_house_category_2022_df.to_csv('전처리_주거실태_2022.csv', index=False, encoding='cp949')\n",
-    "# abode_house_category_2023_df.to_csv('전처리_주거실태_2023.csv', index=False, encoding='cp949')"
+    "# abode_house_category_2023_df.to_csv('전처리_주거실태_2023.csv', index=False, encoding='cp949')\n",
+    "\n",
+    "# '''\n",
+    "# 매매가격지수\n",
+    "# '''\n",
+    "# priceRelative_2021_df.to_csv('전처리_매매가격지수_2021.csv', index=False, encoding='cp949')\n",
+    "# priceRelative_2022_df.to_csv('전처리_매매가격지수_2022.csv', index=False, encoding='cp949')\n",
+    "# priceRelative_2023_df.to_csv('전처리_매매가격지수_2023.csv', index=False, encoding='cp949')\n",
+    "# priceRelative_2024_df.to_csv('전처리_매매가격지수_2024.csv', index=False, encoding='cp949')"
    ]
   },
   {

--- a/python_project_merged.ipynb
+++ b/python_project_merged.ipynb
@@ -89,7 +89,27 @@
     "# 주거실태 (거래량)\n",
     "volume_2021_df = pd.read_csv(pre_root + '주거실태_Data/전처리_거래량_2021.csv', encoding = 'cp949')\n",
     "volume_2022_df = pd.read_csv(pre_root + '주거실태_Data/전처리_거래량_2022.csv', encoding = 'cp949')\n",
-    "volume_2023_df = pd.read_csv(pre_root + '주거실태_Data/전처리_거래량_2023.csv', encoding = 'cp949')"
+    "volume_2023_df = pd.read_csv(pre_root + '주거실태_Data/전처리_거래량_2023.csv', encoding = 'cp949')\n",
+    "\n",
+    "# 주거실태\n",
+    "abode_house_2021_df = pd.read_csv(pre_root + '주거실태_Data/전처리_주거실태_2021.csv', encoding = 'cp949')\n",
+    "abode_house_2022_df = pd.read_csv(pre_root + '주거실태_Data/전처리_주거실태_2022.csv', encoding = 'cp949')\n",
+    "abode_house_2023_df = pd.read_csv(pre_root + '주거실태_Data/전처리_주거실태_2023.csv', encoding = 'cp949')\n",
+    "\n",
+    "# 매매가격지수\n",
+    "priceRelative_2021_df = pd.read_csv(pre_root + '수요공급_Data/전처리_매매가격지수_2021.csv', encoding = 'cp949')\n",
+    "priceRelative_2022_df = pd.read_csv(pre_root + '수요공급_Data/전처리_매매가격지수_2022.csv', encoding = 'cp949')\n",
+    "priceRelative_2023_df = pd.read_csv(pre_root + '수요공급_Data/전처리_매매가격지수_2023.csv', encoding = 'cp949')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6408eac4-663c-4ca4-b910-998cd349602e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "priceRelative_2021_df.drop(columns = '원자료')"
    ]
   },
   {
@@ -104,7 +124,8 @@
     "          공원, 버스, 지하철, 부동산, 개발계획, 수요공급, 유통업체, 의료기관, 인구수, 거래량\n",
     "'''\n",
     "def merge_year_dataFrame(park_df, bus_df, train_df, house_df, develop_df, demandSupply_df,\n",
-    "                         distribute_df, hospital_df, population_df, volume_df, year) :\n",
+    "                         distribute_df, hospital_df, population_df, volume_df,\n",
+    "                         abode_house_df, priceRelative_df, year) :\n",
     "  # 공원\n",
     "  park_df = park_df[['구', '합계_공원수 (개소)']]\n",
     "  \n",
@@ -145,11 +166,18 @@
     "  # 주거실태 (거래량)\n",
     "  volume_df = volume_df.drop(columns = '년도').rename(columns = {'동(호)수' : '거래량'})[['구', '거래량']]\n",
     "\n",
+    "  # 주거실태\n",
+    "  abode_house_df = abode_house_df.drop(columns = '년도')\n",
+    "\n",
+    "  # 매매가격지수 (증감률)\n",
+    "  priceRelative_df = priceRelative_df.drop(columns = '원자료')\n",
+    "\n",
     "  ### 데이터 병합\n",
     "  merge_df = house_df.merge(park_df, on = '구').merge(bus_df, on = '구').merge(train_df, on = '구')\n",
     "  merge_df = merge_df.merge(develop_df, on = '구').merge(demandSupply_df, on = '구')\n",
     "  merge_df = merge_df.merge(distribute_df, on = '구').merge(hospital_df, on = '구')\n",
     "  merge_df = merge_df.merge(population_df, on = '구').merge(volume_df, on = '구')\n",
+    "  merge_df = merge_df.merge(abode_house_df, on = '구').merge(priceRelative_df, on = '구')\n",
     "\n",
     "  merge_df['연도'] = year\n",
     "\n",
@@ -181,16 +209,19 @@
     "merge_year_2021 = merge_year_dataFrame(park_2021_df, bus_2021_df, train_2021_df, house_2021_df,\n",
     "                                       develop_2021_df, demandSupply_2021_df, distribute_2021_df,\n",
     "                                       hospital_2021_df, population_2021_df, volume_2021_df,\n",
+    "                                       abode_house_2021_df, priceRelative_2021_df,\n",
     "                                       year = 2021)\n",
     "\n",
     "merge_year_2022 = merge_year_dataFrame(park_2022_df, bus_2022_df, train_2022_df, house_2022_df,\n",
     "                                       develop_2022_df, demandSupply_2022_df, distribute_2022_df,\n",
     "                                       hospital_2022_df, population_2022_df, volume_2022_df,\n",
+    "                                       abode_house_2022_df, priceRelative_2022_df,\n",
     "                                       year = 2022)\n",
     "\n",
     "merge_year_2023 = merge_year_dataFrame(park_2023_df, bus_2023_df, train_2023_df, house_2023_df,\n",
     "                                       develop_2023_df, demandSupply_2023_df, distribute_2023_df,\n",
     "                                       hospital_2023_df, population_2023_df, volume_2023_df,\n",
+    "                                       abode_house_2023_df, priceRelative_2023_df,\n",
     "                                       year = 2023)"
    ]
   },
@@ -229,6 +260,16 @@
     "\n",
     "# 컬럼명을 '평균시세(천만원)'으로 변경\n",
     "ai_concat.rename(columns={'평균시세': '평균시세(천만원)'}, inplace=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a077823f-8578-4ef6-b678-ba0e7cb973bd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ai_concat"
    ]
   },
   {


### PR DESCRIPTION
매매가격지수 데이터 추가
**기준시점과 매기 조사되는 조사시점의 가격비를 이용하여 기준시점이 100인 수치로 환산한 값을 의미
주택가격지수의 두 시점간 비율이며, 백분비(%)로 표기

본 조사에서는 전월비와 전년 말비를 제공, 제공 산식을 활용하여 원하는 두 시점의 가격 변동률을 구할 수 있음.

(전월비) 당월과 전월의 지수 비율로 전월 대비 평균적인 가격 증감률을 의미

전월비 계산식 = {(당월 - 전월) / 전월} X 100

(전년말비) 당월과 전년말의 지수 비율이며, 전년말 대비 평균적인 가격 증감률을 의미

전년말비 계산식 = {(당월 - 전년말) / 전년말}X 100**


예를 들어 전월지수 105, 당월지수 110의 경우, 전월 대비 변동률은 4.76%(퍼센트), 전월 대비 지수는 5포인트(p)상승으로 표기할 수도 있음.



변동률(%) = {(110 - 105) / 105}X 100 = 4.76퍼센트(%)

변동률(p) = 110 - 105 = 5포인트(p)